### PR TITLE
fix(client): remove `staleTime`

### DIFF
--- a/docs/getting-started/client.md
+++ b/docs/getting-started/client.md
@@ -396,8 +396,6 @@ export default function App({
   return (
     <SessionProvider
       session={session}
-      // Re-fetch session if cache is older than 60 seconds
-      staleTime={60}
       // Re-fetch session every 5 minutes
       refetchInterval={5 * 60}
     >
@@ -412,20 +410,8 @@ export default function App({
 
 Every tab/window maintains its own copy of the local session state; the session is not stored in shared storage like localStorage or sessionStorage. Any update in one tab/window triggers a message to other tabs/windows to update their own session state.
 
-Using low values for `staleTime` or `refetchInterval` will increase network traffic and load on authenticated clients and may impact hosting costs and performance.
+Using low values for `refetchInterval` will increase network traffic and load on authenticated clients and may impact hosting costs and performance.
 :::
-
-#### Stale time
-
-The `staleTime` option is the maximum age a session data can be on the client before it is considered stale.
-
-When `staleTime` is set to `0` (the default) the cache will always be used when `useSession` is called and only explicit calls made to get the session status (i.e. `getSession()`) or event triggers, such as signing in or out in another tab/window, or a tab/window gaining or losing focus, will trigger an update of the session state.
-
-If set to any value other than zero, it specifies in seconds the maximum age of session data on the client before the `useSession()` hook will call the server again to sync the session state.
-
-Unless you have a short session expiry time (e.g. < 24 hours) you probably don't need to change this option. Setting this option to too short a value will increase load (and potentially hosting costs).
-
-The value for `staleTime` should always be lower than the value of the session `maxAge` [session option](/configuration/options#session).
 
 #### Refetch interval
 

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -67,8 +67,8 @@ Version 4 makes using the `SessionProvider` mandatory. This means that you will 
 
 - `Provider` is renamed to `SessionProvider`
 - The options prop is now flattened as the props of SessionProvider.
-- `clientMaxAge` has been renamed to `staleTime`.
 - `keepAlive` has been renamed to `refetchInterval`.
+- `clientMaxAge` has been removed as it's implicit by setting `refetchInterval`.
 
 The best practice for wrapping your app in Providers is to do so in your `pages/_app.jsx` file.
 

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -9,7 +9,7 @@ NextAuth.js version 4 included a few breaking changes from the last major versio
 
 You can find the official Adapters in the [nextauthjs/adapter](https://github.com/nextauthjs/adapters) repository. Although you can still [create your own](/tutorials/creating-a-database-adapter) with a new, [simplified Adapter API](https://github.com/nextauthjs/next-auth/pull/2361).
 
-1.1. If you use the built-in TypeORM or Prisma adapters, these have been removed from the core `next-auth` package to not balloon the package size for users who do not need a database. Thankfully the migration is super easy; you just need to install the external packages for your database and change the import in your `[...nextauth].js`. 
+1.1. If you use the built-in TypeORM or Prisma adapters, these have been removed from the core `next-auth` package to not balloon the package size for users who do not need a database. Thankfully the migration is super easy; you just need to install the external packages for your database and change the import in your `[...nextauth].js`.
 
 The `database` option is gone, you can do the following instead:
 
@@ -68,14 +68,14 @@ Version 4 makes using the `SessionProvider` mandatory. This means that you will 
 - `Provider` is renamed to `SessionProvider`
 - The options prop is now flattened as the props of SessionProvider.
 - `keepAlive` has been renamed to `refetchInterval`.
-- `clientMaxAge` has been removed as it's implicit by setting `refetchInterval`.
+- `clientMaxAge` has been removed in favor of `refetchInterval`, as they overlap in functionality, with the difference that `refetchInterval` will keep re-fetching the session periodically in the background.
 
 The best practice for wrapping your app in Providers is to do so in your `pages/_app.jsx` file.
 
 An example use-case with these new changes:
 
 ```jsx
-import { SessionProvider } from "next-auth/react"
+import { SessionProvider } from "next-auth/react";
 
 export default function App({
   Component,
@@ -87,7 +87,7 @@ export default function App({
     <SessionProvider session={session}>
       <Component {...pageProps} />
     </SessionProvider>
-  )
+  );
 }
 ```
 


### PR DESCRIPTION
## Summary 💭

Following the removal of `staleTime` from the **client module** on `next`, we had to remove references to it in the docs.

Given `staleTime` is already implicitly set when setting `refetchInterval`, do you think we need to reword the `refetchInterval` docs a bit to indicate that? ✍🏼

