### PR TITLE
make `beta` status more prominent

### DIFF
--- a/docs/adapters/dynamodb.md
+++ b/docs/adapters/dynamodb.md
@@ -13,6 +13,10 @@ You can find the full schema in the table structure section below.
 
 ## Getting Started
 
+:::warning
+This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+:::
+
 1. Install `next-auth` and `@next-auth/dynamodb-adapter`
 
 ```bash npm2yarn

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -15,10 +15,10 @@ You can find the Fauna schema and seed information in the docs at [next-auth.js.
 When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
-1. Install `next-auth` and `@next-auth/fauna-adapter@next`
+1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/fauna-adapter
+npm install next-auth@beta @next-auth/fauna-adapter faunadb
 ```
 
 2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -11,7 +11,11 @@ You can find the Fauna schema and seed information in the docs at [next-auth.js.
 
 ## Getting Started
 
-1. Install `next-auth` and `@next-auth/fauna-adapter`
+:::warning
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
+1. Install `next-auth` and `@next-auth/fauna-adapter@next`
 
 ```bash npm2yarn
 npm install next-auth @next-auth/fauna-adapter

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -18,7 +18,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 1. Install `next-auth` and `@next-auth/fauna-adapter@next`
 
 ```bash npm2yarn
-npm install next-auth @next-auth/fauna-adapter
+npm install next-auth@beta @next-auth/fauna-adapter
 ```
 
 2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -12,7 +12,7 @@ You can find the Fauna schema and seed information in the docs at [next-auth.js.
 ## Getting Started
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install `next-auth` and `@next-auth/fauna-adapter@next`

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -9,6 +9,10 @@ This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This p
 
 ## Getting Started
 
+:::warning
+Converting this adapter to support v4 is Work In Progress. See https://github.com/nextauthjs/adapters/pull/183 For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
 1. Install `next-auth` and `@next-auth/firebase-adapter`
 
 ```bash npm2yarn

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -13,10 +13,10 @@ This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This p
 Converting this adapter to support v4 is Work In Progress. See https://github.com/nextauthjs/adapters/pull/183 For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
-1. Install `next-auth` and `@next-auth/firebase-adapter`
+1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/firebase-adapter
+npm install next-auth@beta @next-auth/firebase-adapter@experimental
 ```
 
 2. Add this adapter to your `pages/api/auth/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -16,7 +16,7 @@ Converting this adapter to support v4 is Work In Progress. See https://github.co
 1. Install `next-auth` and `@next-auth/firebase-adapter`
 
 ```bash npm2yarn
-npm install next-auth @next-auth/firebase-adapter
+npm install next-auth@beta @next-auth/firebase-adapter
 ```
 
 2. Add this adapter to your `pages/api/auth/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -10,7 +10,7 @@ This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This p
 ## Getting Started
 
 :::warning
-Converting this adapter to support v4 is Work In Progress. See https://github.com/nextauthjs/adapters/pull/183 For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+Converting this adapter to support v4 is Work In Progress. See https://github.com/nextauthjs/adapters/pull/183 For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install `next-auth` and `@next-auth/firebase-adapter`

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -16,7 +16,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth mongodb @next-auth/mongodb-adapter@next
+npm install next-auth@beta mongodb @next-auth/mongodb-adapter@next
 ```
 
 2. Add `lib/mongodb.js`

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -16,7 +16,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta mongodb @next-auth/mongodb-adapter@next
+npm install next-auth@beta @next-auth/mongodb-adapter@next mongodb
 ```
 
 2. Add `lib/mongodb.js`

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -10,7 +10,7 @@ The MongoDB adapter does not handle connections automatically, so you will have 
 ## Usage
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install the necessary packages

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -9,10 +9,14 @@ The MongoDB adapter does not handle connections automatically, so you will have 
 
 ## Usage
 
+:::warning
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth mongodb @next-auth/mongodb-adapter
+npm install next-auth mongodb @next-auth/mongodb-adapter@next
 ```
 
 2. Add `lib/mongodb.js`

--- a/docs/adapters/pouchdb.md
+++ b/docs/adapters/pouchdb.md
@@ -11,7 +11,12 @@ Depending on your architecture you can use PouchDB's http adapter to reach any d
 
 ## Getting Started
 
-> **Prerequesite**: Your PouchDB instance MUST provide the `pouchdb-find` plugin since it is used internally by the adapter to build and manage indexes
+:::warning
+This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
+
+> **Prerequisites**: Your PouchDB instance MUST provide the `pouchdb-find` plugin since it is used internally by the adapter to build and manage indexes
 
 1. Install `next-auth` and `@next-auth/pouchdb-adapter`
 

--- a/docs/adapters/pouchdb.md
+++ b/docs/adapters/pouchdb.md
@@ -12,7 +12,7 @@ Depending on your architecture you can use PouchDB's http adapter to reach any d
 ## Getting Started
 
 :::warning
-This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -12,7 +12,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 :::
 
 ```bash npm2yarn
-npm install @prisma/client @next-auth/prisma-adapter@next
+npm install next-auth@beta @prisma/client @next-auth/prisma-adapter@next
 npm install prisma --save-dev
 ```
 

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -7,8 +7,12 @@ title: Prisma Adapter
 
 To use this Adapter, you need to install Prisma Client, Prisma CLI, and the separate `@next-auth/prisma-adapter` package:
 
+:::warning
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
 ```bash npm2yarn
-npm install @prisma/client @next-auth/prisma-adapter
+npm install @prisma/client @next-auth/prisma-adapter@next
 npm install prisma --save-dev
 ```
 

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -8,7 +8,7 @@ title: Prisma Adapter
 To use this Adapter, you need to install Prisma Client, Prisma CLI, and the separate `@next-auth/prisma-adapter` package:
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ```bash npm2yarn

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -20,7 +20,7 @@ In the future, we might split up this adapter to support single flavors of SQL f
 To use this Adapter, you need to install the following packages:
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ```bash npm2yarn

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -24,7 +24,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 :::
 
 ```bash npm2yarn
-npm install typeorm @next-auth/typeorm-legacy-adapter@next
+npm install next-auth@beta typeorm @next-auth/typeorm-legacy-adapter@next
 ```
 
 Configure your NextAuth.js to use the TypeORM Adapter:

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -19,8 +19,12 @@ In the future, we might split up this adapter to support single flavors of SQL f
 
 To use this Adapter, you need to install the following packages:
 
+:::warning
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-to-v4#adapters)
+:::
+
 ```bash npm2yarn
-npm install typeorm @next-auth/typeorm-legacy-adapter
+npm install typeorm @next-auth/typeorm-legacy-adapter@next
 ```
 
 Configure your NextAuth.js to use the TypeORM Adapter:

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -24,7 +24,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 :::
 
 ```bash npm2yarn
-npm install next-auth@beta typeorm @next-auth/typeorm-legacy-adapter@next
+npm install next-auth@beta @next-auth/typeorm-legacy-adapter@next typeorm
 ```
 
 Configure your NextAuth.js to use the TypeORM Adapter:

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -54,7 +54,7 @@ export default NextAuth({
 Introduced in https://github.com/nextauthjs/next-auth/releases/tag/v4.0.0-next.8 and https://github.com/nextauthjs/next-auth/pull/2361
 
 :::warning
-When using the **NextAuth v4 beta**, please be sure to use the `next` tagged version of your adapter. For example, to use the appropriate `typeorm` version with NextAuth v4, you would install `@next-auth/typeorm-legacy-adapter@next`. 
+When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For example, to use the appropriate `typeorm` version with NextAuth v4, you would install `@next-auth/typeorm-legacy-adapter@next`. 
 :::
 
 ### Adapter API
@@ -62,6 +62,92 @@ When using the **NextAuth v4 beta**, please be sure to use the `next` tagged ver
 The Adapter API has been rewritten and significantly simplified in NextAuth v4. The adapters now have less work to do as some functionality has been migrated to the core of NextAuth, like hashing the [verification token](/adapters/models/#verification-token).
 
 **This does not require any changes from the user**, however if you are an adapter maintainer or are interested in writing your own adapter, you can find more information about this change in https://github.com/nextauthjs/next-auth/pull/2361 and release https://github.com/nextauthjs/next-auth/releases/tag/v4.0.0-next.22.
+
+### Schema changes
+
+The way we save data with adapters have slightly changed. With the new Adapter API, we wanted to make it easier to extend your database with additional fields. For example if your User needs an extra `phone` field, it should be enough to add that to your database's schema, and no changes will be necessary in your adapter.
+
+- `created_at`/`createdAt` and `updated_at`/`updatedAt` fields are removed from all Models.
+- `user_id`/`userId` consistently named `userId`.
+- `compound_id`/`compundId` is removed from Account.
+- `access_token`/`accessToken` is removed from Session.
+- `email_verified`/`emailVerified` on User is consistently named `email_verified`.
+- `provider_id`/`providerId` renamed to `provider` on Account
+- `provider_type`/`providerType` renamed to `type` on Account
+- `provider_account_id`/`providerAccountId` on Account is consistently named `providerAccountId`
+- `access_token_expires`/`accessTokenExpires` on Account renamed to `expires_in`
+- New fields on Account: `expires_at`, `token_type`, `scope`, `id_token`, `oauth_token_secret`, `oauth_token`, `session_state`
+  
+
+<!-- REVIEW: Would something like this below be helpful? -->
+<details>
+<summary>
+See the changes
+</summary>
+<pre>
+
+```diff
+User {
+  id
+  name
+  email
+- emailVerified
++ email_verified
+  image
+-  created_at
+-  updated_at
+}
+
+Account {
+  id
+- compound_id
+- user_id
++ userId
+-  provider_type
++ type
+- provider_id
++ provider
+- provider_account_id
++ providerAccountId
+  refresh_token
+  access_token
+- access_token_expires
++ expires_in
++ expires_at
++ token_type
++ scope
++ id_token
++ oauth_token_secret
++ oauth_token
++ session_state
+- created_at
+- updated_at
+}
+
+Session {
+  id
+  userId
+  expires
+  sessionToken
+- access_token
+- created_at
+- updated_at
+}
+
+VerificationToken {
+  id
+  token
+  expires
+  identifier
+-  created_at
+-  updated_at
+}
+```
+</pre>
+</details>
+
+
+For more info, see the [Models page](/adapters/models).
 
 ## `next-auth/react`
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ module.exports = {
     announcementBar: {
       id: "new-major-announcement",
       content:
-        "You are looking at the v4 documentation (currently in beta ⚠). If you need the old (v3) documentation, check it out <a href='/v3/getting-started/introduction'>here</a>. Migration docs to v4 <a href='/getting-started/upgrade-v4'>can be found here</a>.",
+        "The default documentation is for v4 , which is currently in beta ⚠. If you need the old (v3) documentation, check it out <a href='/v3/getting-started/introduction'>here</a> (make sure the url contains /v3/). Migration docs to v4 <a href='/getting-started/upgrade-v4'>can be found here</a>.",
       backgroundColor: "#1786fb",
       textColor: "#fff",
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ module.exports = {
     announcementBar: {
       id: "new-major-announcement",
       content:
-        "You are looking at the v4 documentation (currently in beta). 🎉 If you need the old (v3) documentation, check it out <a href='/v3/getting-started/introduction'>here</a>.",
+        "You are looking at the v4 documentation (currently in beta ⚠). If you need the old (v3) documentation, check it out <a href='/v3/getting-started/introduction'>here</a>. Migration docs to v4 <a href='/getting-started/upgrade-v4'>can be found here</a>.",
       backgroundColor: "#1786fb",
       textColor: "#fff",
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -167,7 +167,7 @@ function Home() {
                       href="https://www.npmjs.com/package/next-auth"
                       className="button button--primary button--outline rounded-pill button--lg"
                     >
-                      npm install next-auth
+                      npm install next-auth@beta
                     </a>
                   </p>
                 </div>


### PR DESCRIPTION
There has been a lot of user confusion in the beta phase of our v4 release, so I decided to make this more prominent across the whole documentation. It seems that people don't really read the migration guide, so we have to spread the same information around, and link back to the migration guide more often.

this is not a full PR, I am happy for suggestions if we can do even more!

Similar PR #29