### PR TITLE
fix: add email db requirement reminder

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -93,6 +93,8 @@ Please double check your Email settings.
 
 The Email authentication provider can only be used if a database is configured.
 
+This is required to store the verification token. Please see the [email provider](/providers/email#configuration) for more details.
+
 #### CALLBACK_CREDENTIALS_JWT_ERROR
 
 The Credentials Provider can only be used if JSON Web Tokens are used for sessions.

--- a/docs/providers/email.md
+++ b/docs/providers/email.md
@@ -86,7 +86,9 @@ providers: [
 ],
 ```
 
-3. You can now sign in with an email address at `/api/auth/signin`.
+3. Do not forget to setup one of the database [adapters](/adapters/overview) for storing the Email verification token.
+
+4. You can now sign in with an email address at `/api/auth/signin`.
 
 A user account (i.e. an entry in the Users table) will not be created for the user until the first time they verify their email address. If an email address is already associated with an account, the user will be signed in to that account when they use the link in the email.
 


### PR DESCRIPTION
## Changes 💡

Added step 3. reminder for configuring a database adapter. We actually already mention that the email provider requires a database to be setup in the "TIP" callout before the setup steps, but another reminder can't hurt.

See: https://github.com/nextauthjs/next-auth-example/pull/40

## Affected issues 🎟


## Screenshot (If Applicable) 📷


