### PR TITLE
Update Google Provider Authorization Example to V4

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -39,7 +39,7 @@ Google only provides Refresh Token to an application the first time a user signs
 To force Google to re-issue a Refresh Token, the user needs to remove the application from their account and sign in again:
 https://myaccount.google.com/permissions
 
-Alternatively, you can also pass options in the `authorizationUrl` which will force the Refresh Token to always be provided on sign in, however this will ask all users to confirm if they wish to grant your application access every time they sign in.
+Alternatively, you can also pass options in the `params` object of `authorization` which will force the Refresh Token to always be provided on sign in, however this will ask all users to confirm if they wish to grant your application access every time they sign in.
 
 If you need access to the RefreshToken or AccessToken for a Google account and you are not using a database to persist user accounts, this may be something you need to do.
 
@@ -50,7 +50,13 @@ const options = {
     GoogleProvider({
       clientId: process.env.GOOGLE_ID,
       clientSecret: process.env.GOOGLE_SECRET,
-      authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?prompt=consent&access_type=offline&response_type=code',
+      authorization: {
+        params: {
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code"
+        }
+      }
     })
   ],
   ...


### PR DESCRIPTION

## Changes 💡

authorizationUrl has been replaced by the authorization attribute in V4. I have updated the example to show how to pass these parameters that were previously passed in the authorizationUrl.

I have tested the code of change to the example and it works for me. I did not require passing in the URL component.

This is my first time contributing so I am happy to make any modifications that may be requested of me.

## Affected issues 🎟

I do not currently have an issue for this.

## Screenshot (If Applicable) 📷

Let me know if you would like me to take a picture of the markdown render after the change.

