### PR TITLE
chore: update signing key info

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -124,15 +124,17 @@ jwt: {
   // This is used to generate the actual signingKey and produces a warning
   // message if not defined explicitly.
   secret: 'INp8IvdIyeMcoGAgFGoA61DdBglwwSqnXJZkgz8PSnw',
-  // You can generate a signing key using `jose newkey -s 512 -t oct -a HS512`
+  // You can generate a signing key using `npx node-jose-tools newkey -s 512 -t oct -a HS512`
   // This gives you direct knowledge of the key used to sign the token so you can use it
-  // to authenticate indirectly (eg. to a database driver)
-  signingKey: {
+  // to authenticate indirectly (eg. to a database driver). You should define the signing
+  // key in an environment variable as a string, but if you want to define it here you must 
+  // JSON.stringify the object first.
+  signingKey: JSON.stringify({
      kty: "oct",
      kid: "Dl893BEV-iVE-x9EC52TDmlJUgGm9oZ99_ZL025Hc5Q",
      alg: "HS512",
      k: "K7QqRmJOKRK2qcCKV_pi9PSBv3XP0fpTu30TP8xn4w01xR3ZMZM38yL2DnTVPVw6e4yhdh0jtoah-i4c_pZagA"
-  },
+  }),
   // If you chose something other than the default algorithm for the signingKey (HS512)
   // you also need to configure the algorithm
   verificationOptions: {


### PR DESCRIPTION
## Changes 💡

The `signingKey` / `encryptionKey` jwt options are currently very opaque and inconsistent. I tried to implement the custom signingKey options and with Balaz's help figured out the one or two things that were missing in the docs.

Figured I'd update them to at least a working standard. 

One major question that I still have, is if the signing key details are required to stay private? Like is it considered dangerous to put these directly in the `[...nextauth].js` config and commit that source to github? Should you be using an env var for this at all times like the encryption keys? 

See: https://github.com/nextauthjs/docs/issues/5

## Affected issues 🎟


## Screenshot (If Applicable) 📷


