### PR TITLE
point links in example page to v4 branch

### DIFF
--- a/docs/getting-started/example.md
+++ b/docs/getting-started/example.md
@@ -8,7 +8,7 @@ title: Example Code
 The example code below describes how to add authentication to a Next.js app.
 
 :::tip
-The easiest way to get started is to clone the [example app](https://github.com/nextauthjs/next-auth-example) and follow the instructions in README.md. You can try out a live demo at [next-auth-example.vercel.app](https://next-auth-example.vercel.app)
+The easiest way to get started is to clone the [example app v4 branch](https://github.com/nextauthjs/next-auth-example/tree/ndom91/update-v4) and follow the instructions in README.md. You can try out a live demo at [https://next-auth-example-git-ndom91-update-v4-nextauthjs.vercel.app/](https://next-auth-example-git-ndom91-update-v4-nextauthjs.vercel.app/)
 :::
 
 ### Add API route


### PR DESCRIPTION
The main branch of the [`next-auth-example` repo](https://github.com/nextauthjs/next-auth-example) uses the stable v3 version of NextAuth. 
However, the docs folder in the main  branch of the current `docs` repo refer to the v4 version. 

This creates a confusion when you click on the link from the docs and land on the main branch of the example repo app. Moreover, the example repo's main branch package.json refers "next-auth": "latest" in the package.json file so it's hard to know whether that's v3 or v4 (it's v3).

In this PR I suggest to point the links to the example repo to the v4 branch so that the confusion goes away. Once the v4 branch is merged in the example repo, we can revert this commit.

cf https://github.com/nextauthjs/next-auth-example/pull/40#issuecomment-945520453 for the initial discussion in the example repo

## Changes 💡


## Affected issues 🎟


## Screenshot (If Applicable) 📷


