### PR TITLE
Use correct tenant property for AzureADB2CProvider options

### DIFF
--- a/docs/providers/azure-ad-b2c.md
+++ b/docs/providers/azure-ad-b2c.md
@@ -66,7 +66,7 @@ import AzureADB2CProvider from 'next-auth/providers/azure-ad-b2c';
 ...
 providers: [
   AzureADB2CProvider({
-    tenantName: process.env.AZURE_AD_B2C_TENANT_NAME,
+    tenantId: process.env.AZURE_AD_B2C_TENANT_NAME,
     clientId: process.env.AZURE_AD_B2C_CLIENT_ID,
     clientSecret: process.env.AZURE_AD_B2C_CLIENT_SECRET,
     primaryUserFlow: process.env.AZURE_AD_B2C_PRIMARY_USER_FLOW,
@@ -95,7 +95,7 @@ import AzureADB2CProvider from 'next-auth/providers/azure-ad-b2c';
 ...
 providers: [
   AzureADB2CProvider({
-    tenantName: process.env.AZURE_AD_B2C_TENANT_NAME,
+    tenantId: process.env.AZURE_AD_B2C_TENANT_NAME,
     clientId: process.env.AZURE_AD_B2C_CLIENT_ID,
     clientSecret: process.env.AZURE_AD_B2C_CLIENT_SECRET,
     primaryUserFlow: process.env.AZURE_AD_B2C_PRIMARY_USER_FLOW,


### PR DESCRIPTION
## Changes 💡
Rename `tenantName` to `tenantId` as this is the correct property name.

## Affected issues 🎟


## Screenshot (If Applicable) 📷


