### PR TITLE
Fixed refresh token example

### DIFF
--- a/versioned_docs/version-v3/tutorials/refresh-token-rotation.md
+++ b/versioned_docs/version-v3/tutorials/refresh-token-rotation.md
@@ -5,10 +5,6 @@ title: Refresh Token Rotation
 
 While NextAuth.js doesn't automatically handle access token rotation for OAuth providers yet, this functionality can be implemented using [callbacks](https://next-auth.js.org/configuration/callbacks).
 
-## Source Code
-
-_A working example can be accessed [here](https://github.com/lawrencecchen/next-auth-refresh-tokens)._
-
 ## Implementation
 
 ### Server Side
@@ -75,6 +71,7 @@ async function refreshAccessToken(token) {
 }
 
 export default NextAuth({
+  secret: process.env.NEXTAUTH_SECRET,
   providers: [
     Providers.Google({
       clientId: process.env.GOOGLE_CLIENT_ID,


### PR DESCRIPTION
## Changes 💡

1. Removed 'working example' repo link since it is outdated (doesn't work with v4). If you want to host the updated v4 example, here it is: [next-auth-refresh-tokens.zip](https://github.com/nextauthjs/docs/files/7534885/next-auth-refresh-tokens.zip).
2. Added required secret property to next-auth configuration since this particular example doesn't work without it and throws `JWEDecryptionFailed: decryption operation failed` at random times otherwise.. 

## Affected issues 🎟

N/A, this was only mentioned here: https://github.com/nextauthjs/next-auth/discussions/3016

## Screenshot (If Applicable) 📷

N/A


