### PR TITLE
docs(adapters): v4 mention collection renamed

### DIFF
--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -311,6 +311,7 @@ The way we save data with adapters have slightly changed. With the new Adapter A
 - `provider_account_id`/`providerAccountId` on Account is consistently named `providerAccountId`
 - `access_token_expires`/`accessTokenExpires` on Account renamed to `expires_in`
 - New fields on Account: `expires_at`, `token_type`, `scope`, `id_token`, `session_state`
+- `verificationTokens` collection has been renamed to `verification_tokens` (MongoDB)
 
 <!-- REVIEW: Would something like this below be helpful? -->
 <details>

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -311,7 +311,7 @@ The way we save data with adapters have slightly changed. With the new Adapter A
 - `provider_account_id`/`providerAccountId` on Account is consistently named `providerAccountId`
 - `access_token_expires`/`accessTokenExpires` on Account renamed to `expires_in`
 - New fields on Account: `expires_at`, `token_type`, `scope`, `id_token`, `session_state`
-- `verificationTokens` collection has been renamed to `verification_tokens` (MongoDB)
+- `verification_requests` table has been renamed to `verification_tokens`
 
 <!-- REVIEW: Would something like this below be helpful? -->
 <details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29161,6 +29161,7 @@
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "postcss": "^8.2.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {


### PR DESCRIPTION
## Changes 💡

Mention in the **v4 migration guide** that a collection on the MongoDB adapter was renamed ( from `camelCase` to `snake_case` ).

## Affected issues 🎟

Fixes #110 


