### PR TITLE
feat(providers): Add documentation for Osu! provider

### DIFF
--- a/docs/providers/osu.md
+++ b/docs/providers/osu.md
@@ -1,0 +1,40 @@
+---
+id: osu
+title: Osu!
+---
+
+## Documentation
+
+https://osu.ppy.sh/docs/index.html#authentication
+
+## Configuration
+
+https://osu.ppy.sh/home/account/edit#new-oauth-application
+
+## Options
+
+The **Osu Provider** comes with a set of default options:
+
+- [Osu Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/osu.ts)
+
+You can override any of the options to suit your own use case.
+
+
+:::note
+Osu! does **not** provide an user email!
+:::
+
+
+## Example
+
+```js
+import OsuProvider from `next-auth/providers/osu`
+...
+providers: [
+  OsuProvider({
+    clientId: process.env.OSU_CLIENT_ID,
+    clientSecret: process.env.OSU_CLIENT_SECRET
+  })
+]
+...
+```

--- a/docs/providers/osu.md
+++ b/docs/providers/osu.md
@@ -21,7 +21,7 @@ You can override any of the options to suit your own use case.
 
 
 :::note
-Osu! does **not** provide an user email!
+Osu! does **not** provide a user email!
 :::
 
 


### PR DESCRIPTION
## Changes 💡
Adds the provider documentation for Osu! matching the PR https://github.com/nextauthjs/next-auth/pull/3234

## Affected issues 🎟

Should be merged after https://github.com/nextauthjs/next-auth/pull/3234 is done.

