### PR TITLE
docs(credentials): Add `type`, `id` and remove 1 space on credentials docs

### DIFF
--- a/docs/configuration/providers/credentials.md
+++ b/docs/configuration/providers/credentials.md
@@ -15,14 +15,16 @@ import CredentialsProvider from `next-auth/providers/credentials`
 providers: [
   CredentialsProvider({
     // The name to display on the sign in form (e.g. 'Sign in with...')
+    id: 'credentials-1',
     name: 'Credentials',
+    type: 'credentials',
     // The credentials is used to generate a suitable form on the sign in page.
     // You can specify whatever fields you are expecting to be submitted.
     // e.g. domain, username, password, 2FA token, etc.
     // You can pass any HTML attribute to the <input> tag through the object.
     credentials: {
       username: { label: "Username", type: "text", placeholder: "jsmith" },
-      password: {  label: "Password", type: "password" }
+      password: { label: "Password", type: "password" }
     },
     async authorize(credentials, req) {
       // You need to provide your own logic here that takes the credentials


### PR DESCRIPTION
Add `type`, `id` and remove 1 space

## Changes 💡


## Affected issues 🎟


## Screenshot (If Applicable) 📷


