### PR TITLE
typo in `oath.md`

### DIFF
--- a/docs/configuration/providers/oauth.md
+++ b/docs/configuration/providers/oauth.md
@@ -239,7 +239,7 @@ In the rare case you don't care about what this endpoint returns, or your provid
 
 ```js
 userinfo: {
-  requst: () => {}
+  request: () => {}
 }
 ```
 


### PR DESCRIPTION

## Changes 💡
In the `userinfo` option section of `docs/configuration/providers/oauth.md`,  the key should be `request` instead of `requst`

## Affected issues 🎟


## Screenshot (If Applicable) 📷
![image](https://user-images.githubusercontent.com/19563342/143195058-29e00e5e-bae5-45d2-94a0-5cf6a067e69c.png)

