### PR TITLE
fix: update import strategy

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -22,10 +22,10 @@ You can override any of the options to suit your own use case.
 ## Example
 
 ```js
-import GoogleProvider from `next-auth/providers/google`
+import Providers from `next-auth/providers`
 ...
 providers: [
-  GoogleProvider({
+  Providers.Google({
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET
   })


### PR DESCRIPTION
The way as the providers are imported in the example is wrong due to following this proposal, the linter throws an error.

This proposed update is based on the official documentation provided in the GitHub repository: https://github.com/nextauthjs/next-auth#add-api-route

## Changes 💡


## Affected issues 🎟


## Screenshot (If Applicable) 📷


