### PR TITLE
Update prisma.md to reference shadow databases within db datasource.

### DIFF
--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -49,7 +49,7 @@ You need to use at least Prisma 2.26.0. Create a schema file in `prisma/schema.p
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  shadowDatabaseUrl = env("SHADOW_DATABASE_URL") // Support added in Prisma v2.17.0. Allows Prisma to migrate when using a cloud provider that doesn't support the creation of new databases, like Heroku.
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL") // Only needed when using a cloud provider that doesn't support the creation of new databases, like Heroku. Learn more: https://pris.ly/migrate-shadow
 }
 
 generator client {

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -49,6 +49,7 @@ You need to use at least Prisma 2.26.0. Create a schema file in `prisma/schema.p
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL") // Support added in Prisma v2.17.0. Allows Prisma to migrate when using a cloud provider that doesn't support the creation of new databases, like Heroku.
 }
 
 generator client {


### PR DESCRIPTION
Cloud providers that don't support the creation of databases can't migrate an existing DB without specifying a shadow database. Users will see this error:
```
Error: P3014

Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. Read more about the shadow database (and workarounds) at https://pris.ly/d/migrate-shadow

Original error: 
db error: ERROR: permission denied to create database
   0: sql_migration_connector::flavour::postgres::sql_schema_from_migration_history
             at migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs:354
   1: migration_core::api::DevDiagnostic
             at migration-engine/core/src/api.rs:108
```

This caught me off guard when setting up Prisma as my adapter. Despite there [being a link to documentation](https://pris.ly/d/migrate-shadow), this is an error users will inevitably run into. It would be nice to see this called out.

## Changes 💡
Introduced new field to the db datasource + comment that explains why this might be required.

## Affected issues 🎟
Anyone using a cloud provider like Heroku that doesn't support the creation of databases.

## Screenshot (If Applicable) 📷

<img width="717" alt="Screen Shot 2021-11-28 at 6 29 03 PM" src="https://user-images.githubusercontent.com/25316168/143799665-e50d5885-9252-480f-a459-ab071897f26e.png">

