### PR TITLE
docs(providers): update GitHub tip with new next-auth behavior

### DIFF
--- a/docs/providers/github.md
+++ b/docs/providers/github.md
@@ -43,5 +43,5 @@ Only allows one callback URL per Client ID / Client Secret.
 :::
 
 :::tip
-Email address is not returned if privacy settings are enabled.
+Email address is always returned, even if the user doesn't have a public email address on their profile.
 :::


### PR DESCRIPTION
## Changes 💡

Tip updated to reflect new behavior from [nextauthjs/next-auth#3302](https://github.com/nextauthjs/next-auth/pull/3302)

