### PR TITLE
[Fix] Typo in options.md

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -126,7 +126,7 @@ session: {
 
 #### Description
 
-JSON Web Tokens can be used for session tokens if enabled with `session: { session: "jwt" }` option. JSON Web Tokens are enabled by default if you have not specified a database.
+JSON Web Tokens can be used for session tokens if enabled with `session: { strategy: "jwt" }` option. JSON Web Tokens are enabled by default if you have not specified a database.
 
 By default JSON Web Tokens are encrypted (JWE). We recommend you keep this behavoiur, but you can override it by defining your own `encode` and `decode` methods.
 


### PR DESCRIPTION
- Fix typo session to strategy: jwt section

```js
session: {
  strategy: "database",
  maxAge: 30 * 24 * 60 * 60, // 30 days
  updateAge: 24 * 60 * 60, // 24 hours
}
```

There is no `session` in the session's property.
I changed `session` to `strategy`.

## Changes 💡


## Affected issues 🎟


## Screenshot (If Applicable) 📷


