### PR TITLE
feat: remove beta info from docs

### DIFF
--- a/docs/adapters/dgraph.md
+++ b/docs/adapters/dgraph.md
@@ -8,7 +8,7 @@ title: Dgraph
 This is the Dgraph Adapter for [`next-auth`](https://next-auth.js.org).
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ## Getting Started
@@ -16,7 +16,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/dgraph-adapter@next
+npm install next-auth @next-auth/dgraph-adapter@next
 ```
 
 2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/dgraph.md
+++ b/docs/adapters/dgraph.md
@@ -7,10 +7,6 @@ title: Dgraph
 
 This is the Dgraph Adapter for [`next-auth`](https://next-auth.js.org).
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 ## Getting Started
 
 1. Install the necessary packages
@@ -36,7 +32,7 @@ export default NextAuth({
 
     // you can omit the following properties if you are running an unsecure schema
     authHeader: process.env.AUTH_HEADER, // default: "Authorization",
-    jwtSecret: process.env.SECRET
+    jwtSecret: process.env.SECRET,
   }),
 })
 ```
@@ -50,6 +46,7 @@ This approach is not secure or for production use, and does not require a `jwtSe
 :::
 
 #### Unsecure schema
+
 ```graphql
 type Account {
   id: ID
@@ -97,6 +94,7 @@ For production deployments you will want to restrict the access to the types use
 by next-auth. The main form of access control used in Dgraph is via `@auth` directive alongide types in the schema.
 
 #### Secure schema
+
 ```graphql
 type Account
   @auth(

--- a/docs/adapters/dynamodb.md
+++ b/docs/adapters/dynamodb.md
@@ -13,10 +13,6 @@ You can find the full schema in the table structure section below.
 
 ## Getting Started
 
-:::warning
-This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 1. Install `next-auth` and `@next-auth/dynamodb-adapter`
 
 ```bash npm2yarn

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -12,13 +12,13 @@ You can find the Fauna schema and seed information in the docs at [next-auth.js.
 ## Getting Started
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/fauna-adapter faunadb
+npm install next-auth @next-auth/fauna-adapter faunadb
 ```
 
 2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/fauna.md
+++ b/docs/adapters/fauna.md
@@ -11,10 +11,6 @@ You can find the Fauna schema and seed information in the docs at [next-auth.js.
 
 ## Getting Started
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 1. Install the necessary packages
 
 ```bash npm2yarn

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -9,10 +9,6 @@ This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This p
 
 ## Getting Started
 
-:::warning
-Converting this adapter to support v4 is Work In Progress. See https://github.com/nextauthjs/adapters/pull/183 For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 1. Install the necessary packages
 
 ```bash npm2yarn

--- a/docs/adapters/firebase.md
+++ b/docs/adapters/firebase.md
@@ -16,7 +16,7 @@ Converting this adapter to support v4 is Work In Progress. See https://github.co
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/firebase-adapter@experimental
+npm install next-auth @next-auth/firebase-adapter@experimental
 ```
 
 2. Add this adapter to your `pages/api/auth/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -10,13 +10,13 @@ The MongoDB adapter does not handle connections automatically, so you will have 
 ## Usage
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/mongodb-adapter@next mongodb
+npm install next-auth @next-auth/mongodb-adapter@next mongodb
 ```
 
 2. Add `lib/mongodb.js`

--- a/docs/adapters/mongodb.md
+++ b/docs/adapters/mongodb.md
@@ -9,10 +9,6 @@ The MongoDB adapter does not handle connections automatically, so you will have 
 
 ## Usage
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 1. Install the necessary packages
 
 ```bash npm2yarn

--- a/docs/adapters/neo4j.md
+++ b/docs/adapters/neo4j.md
@@ -10,13 +10,13 @@ This is the Neo4j Adapter for [`next-auth`](https://next-auth.js.org). This pack
 ## Getting Started
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/neo4j-adapter@next neo4j-driver
+npm install next-auth @next-auth/neo4j-adapter@next neo4j-driver
 ```
 
 2. Add this adapter to your `pages/api/[...nextauth].js` next-auth configuration object.

--- a/docs/adapters/neo4j.md
+++ b/docs/adapters/neo4j.md
@@ -9,10 +9,6 @@ This is the Neo4j Adapter for [`next-auth`](https://next-auth.js.org). This pack
 
 ## Getting Started
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 1. Install the necessary packages
 
 ```bash npm2yarn

--- a/docs/adapters/pouchdb.md
+++ b/docs/adapters/pouchdb.md
@@ -11,10 +11,6 @@ Depending on your architecture you can use PouchDB's http adapter to reach any d
 
 ## Getting Started
 
-:::warning
-This adapter currently doesn't support the `next-auth` v4. If you want to help to migrate it, please open a PR/issue. Source code is here: https://github.com/nextauthjs/adapters/tree/main/packages/pouchdb For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 > **Prerequisites**: Your PouchDB instance MUST provide the `pouchdb-find` plugin since it is used internally by the adapter to build and manage indexes
 
 1. Install `next-auth` and `@next-auth/pouchdb-adapter`

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -7,10 +7,6 @@ title: Prisma
 
 To use this Adapter, you need to install Prisma Client, Prisma CLI, and the separate `@next-auth/prisma-adapter` package:
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 ```bash npm2yarn
 npm install next-auth @prisma/client @next-auth/prisma-adapter@next
 npm install prisma --save-dev

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -8,11 +8,11 @@ title: Prisma
 To use this Adapter, you need to install Prisma Client, Prisma CLI, and the separate `@next-auth/prisma-adapter` package:
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ```bash npm2yarn
-npm install next-auth@beta @prisma/client @next-auth/prisma-adapter@next
+npm install next-auth @prisma/client @next-auth/prisma-adapter@next
 npm install prisma --save-dev
 ```
 

--- a/docs/adapters/sequelize.md
+++ b/docs/adapters/sequelize.md
@@ -8,7 +8,7 @@ title: Sequelize
 This is the Sequelize Adapter for [`next-auth`](https://next-auth.js.org).
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ## Getting Started
@@ -16,7 +16,7 @@ When using the **NextAuth v4 beta**, please make sure to use the `next` tagged v
 1. Install the necessary packages
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/sequelize-adapter@next sequelize
+npm install next-auth @next-auth/sequelize-adapter@next sequelize
 ```
 
 :::warning

--- a/docs/adapters/sequelize.md
+++ b/docs/adapters/sequelize.md
@@ -7,10 +7,6 @@ title: Sequelize
 
 This is the Sequelize Adapter for [`next-auth`](https://next-auth.js.org).
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 ## Getting Started
 
 1. Install the necessary packages

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -20,11 +20,11 @@ In the future, we might split up this adapter to support single flavors of SQL f
 To use this Adapter, you need to install the following packages:
 
 :::warning
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
 :::
 
 ```bash npm2yarn
-npm install next-auth@beta @next-auth/typeorm-legacy-adapter@next typeorm
+npm install next-auth @next-auth/typeorm-legacy-adapter@next typeorm
 ```
 
 Configure your NextAuth.js to use the TypeORM Adapter:

--- a/docs/adapters/typeorm.md
+++ b/docs/adapters/typeorm.md
@@ -19,10 +19,6 @@ In the future, we might split up this adapter to support single flavors of SQL f
 
 To use this Adapter, you need to install the following packages:
 
-:::warning
-When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For more info on adapter changes, see [the migration docs](/getting-started/upgrade-v4#adapters)
-:::
-
 ```bash npm2yarn
 npm install next-auth @next-auth/typeorm-legacy-adapter@next typeorm
 ```

--- a/docs/configuration/initialization.md
+++ b/docs/configuration/initialization.md
@@ -114,7 +114,7 @@ export default async function auth(req, res) {
 }
 ```
 
-For more details on all available actions and which methods are supported, please check out the [REST API documentation](/getting-started/rest-api) or the appropriate area in [the source code](https://github.com/nextauthjs/next-auth/blob/beta/src/core/index.ts)
+For more details on all available actions and which methods are supported, please check out the [REST API documentation](/getting-started/rest-api) or the appropriate area in [the source code](https://github.com/nextauthjs/next-auth/blob/main/src/core/index.ts)
 
 This way of initializing `NextAuth` is very powerful, but should be used sparingly.
 

--- a/docs/configuration/providers/oauth.md
+++ b/docs/configuration/providers/oauth.md
@@ -385,7 +385,7 @@ If you think your custom provider might be useful to others, we encourage you to
 
 You only need to add two changes:
 
-1. Add your config: [`src/providers/{provider}.ts`](https://github.com/nextauthjs/next-auth/tree/beta/src/providers)<br />
+1. Add your config: [`src/providers/{provider}.ts`](https://github.com/nextauthjs/next-auth/tree/main/src/providers)<br />
    • make sure you use a named default export, like this: `export default function YourProvider`
 2. Add provider documentation: [`/docs/providers/{provider}.md`](https://github.com/nextauthjs/docs/tree/main/docs/providers)
 

--- a/docs/getting-started/example.md
+++ b/docs/getting-started/example.md
@@ -7,7 +7,7 @@ The example code below describes how to add authentication to a Next.js app.
 
 ## New Project
 
-The easiest way to get started is to clone the [example app v4 branch](https://github.com/nextauthjs/next-auth-example/tree/ndom91/update-v4) and follow the instructions in README.md. You can try out a live demo at [https://next-auth-example-git-ndom91-update-v4-nextauthjs.vercel.app/](https://next-auth-example-git-ndom91-update-v4-nextauthjs.vercel.app/)
+The easiest way to get started is to clone the [example app v4 branch](https://github.com/nextauthjs/next-auth-example/tree/ndom91/update-v4) and follow the instructions in README.md. You can try out a live demo at [https://next-auth-example.vercel.app/](https://next-auth-example.vercel.app/)
 
 ## Existing Project
 

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -17,14 +17,6 @@ You can upgrade to the new version by running:
 npm install next-auth
 ```
 
-#### Verify the correct version
-
-:::warning
-Due to an [unfortunate publish on npm](https://www.npmjs.com/package/next-auth/v/4.0.0), there was already a `4.0.0` version out there that is **NOT** suitable for use. Please make sure to use at least `4.0.1`.
-
-We are sorry for any inconvenience this may have caused.
-:::
-
 ## `next-auth/jwt`
 
 We no longer have a default export in `next-auth/jwt`.

--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -6,23 +6,23 @@ title: Upgrade Guide (v4)
 NextAuth.js version 4 includes a few breaking changes from the last major version (3.x). So we're here to help you upgrade your applications as smoothly as possible. It should be possible to upgrade from any version of 3.x to the latest 4 release by following the next few migration steps.
 
 :::note
-Version 4 is currently in beta. We encourage users to try it out as we don't plan to change the API any more, but be aware that if a bug-fix requires so, we will do that without further notice.
+Version 4 has been released to GA 🚨
+
+We encourage users to try it out and report any and all issues they come across.
 :::
 
 You can upgrade to the new version by running:
 
 ```bash npm2yarn
-npm install next-auth@beta
+npm install next-auth
 ```
 
 #### Verify the correct version
 
 :::warning
-Due to an [unfortunate publish on npm](https://www.npmjs.com/package/next-auth/v/4.0.0), there is a `4.0.0` version out there that is **NOT** suitable for use. During the beta release phase, please make sure/double check your `node_modules/next-auth/package.json` version to be exactly `4.0.0-beta.1` (or `beta.2` etc.), instead of `4.0.0`. (Adapters might try to install the wrong version in some cases for example.)
+Due to an [unfortunate publish on npm](https://www.npmjs.com/package/next-auth/v/4.0.0), there was already a `4.0.0` version out there that is **NOT** suitable for use. Please make sure to use at least `4.0.1`.
 
-In your project's `package.json`, make sure you don't have a `^` character before the version number. Read more in the [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies).
-
-We are sorry for this inconvenience, and we will remedy this issue as soon as v4 goes stable.
+We are sorry for any inconvenience this may have caused.
 :::
 
 ## `next-auth/jwt`
@@ -282,11 +282,9 @@ export default NextAuth({
 Introduced in https://github.com/nextauthjs/next-auth/releases/tag/v4.0.0-next.8 and https://github.com/nextauthjs/next-auth/pull/2361
 
 :::warning IMPORTANT
-When using the **NextAuth v4 beta**, please make sure to use the `next` tagged version of your adapter. For example, to use the appropriate `typeorm` version with NextAuth v4, you would:
+When using the **NextAuth v4**, please make sure to use the `next` tagged version of your adapter. For example, to use the appropriate `typeorm` version with NextAuth v4, you would:
 
 `npm install @next-auth/typeorm-legacy-adapter@next`
-
-If you have issues installing `@next` adapters with npm due to the required `4.0.0-beta.X` version of `next-auth` and a `4.0.0` package already existing, please use the `--force-legacy-deps` flag with `npm install`.
 :::
 
 ### Adapter API

--- a/docs/providers/slack.md
+++ b/docs/providers/slack.md
@@ -22,7 +22,7 @@ Slack requires you that the redirect URL of your app uses `https`, even for loca
 
 The **Slack Provider** comes with a set of default options:
 
-- [Slack Provider options](https://github.com/nextauthjs/next-auth/blob/beta/src/providers/slack.ts)
+- [Slack Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/slack.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ module.exports = {
     announcementBar: {
       id: "new-major-announcement",
       content:
-        "The default documentation is for v4, which is currently in beta 🚨 migration to <b>v4</b> docs can be found <a href='/getting-started/upgrade-v4'>here</a> 👈 The old v3 docs can be found <a href='/v3/getting-started/introduction'>here</a>.",
+        "The default documentation is for v4 which has been released to GA 🚨 migration to <b>v4</b> docs can be found <a href='/getting-started/upgrade-v4'>here</a> 👈 The old v3 docs can be found <a href='/v3/getting-started/introduction'>here</a>.",
       backgroundColor: "#1786fb",
       textColor: "#fff",
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -168,7 +168,7 @@ function Home() {
                       href="https://www.npmjs.com/package/next-auth"
                       className="button button--primary button--outline rounded-pill button--lg"
                     >
-                      npm install next-auth@beta
+                      npm install next-auth
                     </a>
                   </p>
                 </div>


### PR DESCRIPTION
## Changes 💡

Removed the `beta` tags and infos from a few places in the docs, including links that pointed specifically to github beta branch files. These links were changed to `main`, therefore if the file doesnt exist yet, the vercel build may fail at the docusaurus dead link check for now.

Therefore, these links may have to be reverted to `beta` and follow-up with another PR to change them to `main`, or somehow force the build/deploy, if they are blocking on vercel.

## Affected issues 🎟


## Screenshot (If Applicable) 📷


