### PR TITLE
docs: cleanup credentials provider page + homepage example syntaxhighlighting

### DIFF
--- a/docs/providers/credentials.md
+++ b/docs/providers/credentials.md
@@ -124,25 +124,4 @@ providers: [
 ]
 ```
 
-### Example UI
-
-This example below shows a complex configuration is rendered by the built in sign in page.
-
-You can also [use a custom sign in page](/configuration/pages#credentials-sign-in) if you want to provide a custom user experience.
-
-<Image src="/img/signin-complex.png"/>
-
-```js
-export const Image = ({ children, src, alt = "" }) => (
-  <div
-    style={{
-      padding: "0.2rem",
-      width: "100%",
-      display: "flex",
-      justifyContent: "center",
-    }}
-  >
-    <img alt={alt} src={src} />
-  </div>
-)
-```
+![](/img/signin-complex.png)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -186,7 +186,7 @@ function Home() {
                     <h4 className="code-heading">
                       Server <span>/pages/api/auth/[...nextauth].js</span>
                     </h4>
-                    <CodeBlock className="javascript">
+                    <CodeBlock className="prism-code language-js">
                       {serverlessFunctionCode}
                     </CodeBlock>
                   </div>
@@ -196,11 +196,11 @@ function Home() {
                     <h4 className="code-heading">
                       Client (App) <span>/pages/_app.jsx</span>
                     </h4>
-                    <CodeBlock className="javascript">{appCode}</CodeBlock>
+                    <CodeBlock className="prism-code language-js">{appCode}</CodeBlock>
                     <h4 className="code-heading">
                       Client (Page) <span>/pages/index.js</span>
                     </h4>
-                    <CodeBlock className="javascript">{pageCode}</CodeBlock>
+                    <CodeBlock className="prism-code language-js">{pageCode}</CodeBlock>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Changes 💡

The Credentials Provider page somehow got an additional code block with a nonsense example. That is cleaned up.

Also the code examples / snippets on the homepage were lacking syntax highlighting, that is also remedied here.


## Affected issues 🎟


## Screenshot (If Applicable) 📷


