### PR TITLE
Fix Okta Provider options link

### DIFF
--- a/docs/providers/okta.md
+++ b/docs/providers/okta.md
@@ -11,7 +11,7 @@ https://developer.okta.com/docs/reference/api/oidc
 
 The **Okta Provider** comes with a set of default options:
 
-- [Okta Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/okta.js)
+- [Okta Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/okta.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
## Changes 💡
The file being linked to was renamed from `.js` to `.ts`. This updates the link to https://github.com/nextauthjs/next-auth/blob/main/src/providers/okta.ts.


## Affected issues 🎟


## Screenshot (If Applicable) 📷


