### PR TITLE
Fix Credentials Provider options link

### DIFF
--- a/docs/providers/credentials.md
+++ b/docs/providers/credentials.md
@@ -19,7 +19,7 @@ The functionality provided for credentials based authentication is intentionally
 
 The **Credentials Provider** comes with a set of default options:
 
-- [Credentials Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/credentials.js)
+- [Credentials Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/credentials.ts)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
It seems at some point the file went from `.js` to `.ts`
