### PR TITLE
fix: add missing `created_at` field

### DIFF
--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -68,6 +68,7 @@ model Account {
   session_state      String?
   oauth_token_secret String?
   oauth_token        String?
+  created_at         Int?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -147,6 +148,7 @@ model Account {
   scope              String?
   id_token           String?
   session_state      String?
+  created_at         Int?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -68,7 +68,6 @@ model Account {
   session_state      String?
   oauth_token_secret String?
   oauth_token        String?
-  created_at         Int?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -148,7 +147,6 @@ model Account {
   scope              String?
   id_token           String?
   session_state      String?
-  created_at         Int?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/docs/providers/42.md
+++ b/docs/providers/42.md
@@ -3,6 +3,10 @@ id: 42-school
 title: 42 School
 ---
 
+:::note
+42 returns a field on `Account` called `created_at` which is a number. See the [docs](https://api.intra.42.fr/apidoc/guides/getting_started#make-basic-requests). Make sure to add this field to your database schema, in case if you are using an [Adapter](/adapters/overview).
+:::
+
 ## Documentation
 
 https://api.intra.42.fr/apidoc/guides/web_application_flow


### PR DESCRIPTION
## Changes 💡
Add a missing `created_at` field as its needed to create the account table, without it prisma throws the error bellow

![image](https://user-images.githubusercontent.com/57002508/144633998-63422644-9a83-4adf-a9ee-f9e7c5fdd3c6.png)

## Affected issues 🎟


## Screenshot (If Applicable) 📷


