### PR TITLE
docs: fix broken provider links due to v4 landing on main

### DIFF
--- a/docs/providers/42.md
+++ b/docs/providers/42.md
@@ -19,7 +19,7 @@ https://profile.intra.42.fr/oauth/applications/new
 
 The **42 School Provider** comes with a set of default options:
 
-- [42 School Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/42.js)
+- [42 School Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/42.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/apple.md
+++ b/docs/providers/apple.md
@@ -15,7 +15,7 @@ https://developer.apple.com/account/resources/identifiers/list/serviceId
 
 The **Apple Provider** comes with a set of default options:
 
-- [Apple Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/apple.js)
+- [Apple Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/apple.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/atlassian.md
+++ b/docs/providers/atlassian.md
@@ -11,7 +11,7 @@ https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-g
 
 The **Atlassian Provider** comes with a set of default options:
 
-- [Atlassian Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/atlassian.js)
+- [Atlassian Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/atlassian.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/auth0.md
+++ b/docs/providers/auth0.md
@@ -19,7 +19,7 @@ Configure your application in Auth0 as a 'Regular Web Application' (not a 'Singl
 
 The **Auth0 Provider** comes with a set of default options:
 
-- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/auth0.js)
+- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/auth0.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/azure-ad-b2c.md
+++ b/docs/providers/azure-ad-b2c.md
@@ -4,11 +4,11 @@ title: Azure Active Directory B2C
 ---
 
 :::note
-Azure AD B2C returns the following fields on `Account`: 
-- `refresh_token_expires_in` (number) 
+Azure AD B2C returns the following fields on `Account`:
+- `refresh_token_expires_in` (number)
 - `not_before` (number)
 - `id_token_expires_in` (number)
-- `profile_info` (string). 
+- `profile_info` (string).
 
 See their [docs](https://docs.microsoft.com/en-us/azure/active-directory-b2c/access-tokens). Remember to add these fields to your database schema, in case if you are using an [Adapter](/adapters/overview).
 :::
@@ -25,7 +25,7 @@ https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant
 
 The **Azure Active Directory Provider** comes with a set of default options:
 
-- [Azure Active Directory Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/azure-ad-b2c.js)
+- [Azure Active Directory Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/azure-ad-b2c.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/cognito.md
+++ b/docs/providers/cognito.md
@@ -17,7 +17,7 @@ You need to select your AWS region to go the the Cognito dashboard.
 
 The **Amazon Cognito Provider** comes with a set of default options:
 
-- [Amazon Cognito Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/cognito.js)
+- [Amazon Cognito Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/cognito.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/email.md
+++ b/docs/providers/email.md
@@ -25,7 +25,7 @@ The Email Provider can be used with both JSON Web Tokens and database sessions, 
 
 The **Email Provider** comes with a set of default options:
 
-- [Email Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/email.js)
+- [Email Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/email.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/facebook.md
+++ b/docs/providers/facebook.md
@@ -15,7 +15,7 @@ https://developers.facebook.com/apps/
 
 The **Facebook Provider** comes with a set of default options:
 
-- [Facebook Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/facebook.js)
+- [Facebook Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/facebook.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -15,7 +15,7 @@ https://console.developers.google.com/apis/credentials
 
 The **Google Provider** comes with a set of default options:
 
-- [Google Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/google.js)
+- [Google Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/google.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/keycloak.md
+++ b/docs/providers/keycloak.md
@@ -17,7 +17,7 @@ Create an openid-connect client in Keycloak with "confidential" as the "Access T
 
 The **Keycloak Provider** comes with a set of default options:
 
-- [Keycloak Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/keycloak.js)
+- [Keycloak Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/keycloak.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/line.md
+++ b/docs/providers/line.md
@@ -15,7 +15,7 @@ https://developers.line.biz/console/
 
 The **Line Provider** comes with a set of default options:
 
-- [Line Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/line.js)
+- [Line Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/line.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/linkedin.md
+++ b/docs/providers/linkedin.md
@@ -19,7 +19,7 @@ From the Auth tab get the client ID and client secret. On the same tab, add redi
 
 The **LinkedIn Provider** comes with a set of default options:
 
-- [LinkedIn Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/linkedin.js)
+- [LinkedIn Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/linkedin.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/pipedrive.md
+++ b/docs/providers/pipedrive.md
@@ -11,7 +11,7 @@ https://pipedrive.readme.io/docs/marketplace-oauth-authorization
 
 The **Pipedrive Provider** comes with a set of default options:
 
-- [Pipedrive Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/pipedrive.js)
+- [Pipedrive Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/pipedrive.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/spotify.md
+++ b/docs/providers/spotify.md
@@ -15,7 +15,7 @@ https://developer.spotify.com/dashboard/applications
 
 The **Spotify Provider** comes with a set of default options:
 
-- [Spotify Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/spotify.js)
+- [Spotify Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/spotify.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/twitch.md
+++ b/docs/providers/twitch.md
@@ -17,7 +17,7 @@ Add the following redirect URL into the console `http://<your-next-app-url>/api/
 
 The **Twitch Provider** comes with a set of default options:
 
-- [Twitch Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitch.js)
+- [Twitch Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitch.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/twitter.md
+++ b/docs/providers/twitter.md
@@ -19,7 +19,7 @@ https://developer.twitter.com/en/apps
 
 The **Twitter Provider** comes with a set of default options:
 
-- [Twitter Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitter.js)
+- [Twitter Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitter.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docs/providers/zoom.md
+++ b/docs/providers/zoom.md
@@ -15,7 +15,7 @@ https://marketplace.zoom.us
 
 The **Zoom Provider** comes with a set of default options:
 
-- [Zoom Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/zoom.js)
+- [Zoom Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/zoom.ts)
 
 You can override any of the options to suit your own use case.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,7 +90,7 @@ module.exports = {
                 alt="Powered by Vercel"
                 style="margin-top: 8px"
                 height="32"
-                src="https://raw.githubusercontent.com/nextauthjs/next-auth/main/www/static/img/powered-by-vercel.svg"
+                src="https://raw.githubusercontent.com/nextauthjs/docs/main/static/img/powered-by-vercel.svg"
               />
             </a>`,
             },

--- a/versioned_docs/version-v3/configuration/pages.md
+++ b/versioned_docs/version-v3/configuration/pages.md
@@ -40,8 +40,8 @@ Example: `/auth/error?error=Configuration`
 
 The following errors are passed as error query parameters to the default or overriden sign-in page:
 
-- **OAuthSignin**: Error in constructing an authorization URL ([1](https://github.com/nextauthjs/next-auth/blob/457952bb5abf08b09861b0e5da403080cd5525be/src/server/lib/signin/oauth.js), [2](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/oauth/state-handler.js)),
-- **OAuthCallback**: Error in handling the response ([1](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/oauth/callback.js), [2](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/main/src/server/lib/oauth/state-handler.js)) from an OAuth provider.
+- **OAuthSignin**: Error in constructing an authorization URL ([1](https://github.com/nextauthjs/next-auth/blob/457952bb5abf08b09861b0e5da403080cd5525be/src/server/lib/signin/oauth.js), [2](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/state-handler.js)),
+- **OAuthCallback**: Error in handling the response ([1](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/callback.js), [2](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/pkce-handler.js), [3](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/server/lib/oauth/state-handler.js)) from an OAuth provider.
 - **OAuthCreateAccount**: Could not create OAuth provider user in the database.
 - **EmailCreateAccount**: Could not create email provider user in the database.
 - **Callback**: Error in the [OAuth callback handler route](https://github.com/nextauthjs/next-auth/blob/main/src/server/routes/callback.js)

--- a/versioned_docs/version-v3/configuration/providers.md
+++ b/versioned_docs/version-v3/configuration/providers.md
@@ -30,7 +30,7 @@ NextAuth.js is designed to work with any OAuth service, it supports **OAuth 1.0*
       <span className="provider-name-list__comma">,</span>
     </span>
   )
-    
+
 )}
 </div>
 
@@ -184,10 +184,10 @@ You only need to add two changes:
 
 1. Add your config: [`src/providers/{provider}.js`](https://github.com/nextauthjs/next-auth/tree/main/src/providers)<br />
    • make sure you use a named default export, like this: `export default function YourProvider`
-2. Add provider documentation: [`www/docs/providers/{provider}.md`](https://github.com/nextauthjs/next-auth/tree/main/www/docs/providers)
-3. Add it to our [provider types](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts) (for TS projects)<br />
-   • you just need to add your new provider name to [this list](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts#L56-L97)<br />
-   • in case you new provider accepts some custom options, you can [add them here](https://github.com/nextauthjs/next-auth/blob/main/types/providers.d.ts#L48-L53)
+2. Add provider documentation: [`www/docs/providers/{provider}.md`](https://github.com/nextauthjs/next-auth/tree/ead715219a5d7a6e882a6ba27fa56b03954d062d/www/docs/providers)
+3. Add it to our [provider types](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/types/providers.d.ts) (for TS projects)<br />
+   • you just need to add your new provider name to [this list](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/types/providers.d.ts#L56-L97)<br />
+   • in case you new provider accepts some custom options, you can [add them here](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/types/providers.d.ts#L48-L53)
 
 That's it! 🎉 Others will be able to discover this provider much more easily now!
 

--- a/versioned_docs/version-v3/providers/42.md
+++ b/versioned_docs/version-v3/providers/42.md
@@ -15,7 +15,7 @@ https://profile.intra.42.fr/oauth/applications/new
 
 The **42 School Provider** comes with a set of default options:
 
-- [42 School Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/42.js)
+- [42 School Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/42.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/apple.md
+++ b/versioned_docs/version-v3/providers/apple.md
@@ -15,7 +15,7 @@ https://developer.apple.com/account/resources/identifiers/list/serviceId
 
 The **Apple Provider** comes with a set of default options:
 
-- [Apple Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/apple.js)
+- [Apple Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/apple.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/atlassian.md
+++ b/versioned_docs/version-v3/providers/atlassian.md
@@ -11,7 +11,7 @@ https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-g
 
 The **Atlassian Provider** comes with a set of default options:
 
-- [Atlassian Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/atlassian.js)
+- [Atlassian Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/atlassian.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/auth0.md
+++ b/versioned_docs/version-v3/providers/auth0.md
@@ -19,7 +19,7 @@ Configure your application in Auth0 as a 'Regular Web Application' (not a 'Singl
 
 The **Auth0 Provider** comes with a set of default options:
 
-- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/auth0.js)
+- [Auth0 Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/auth0.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/azure-ad-b2c.md
+++ b/versioned_docs/version-v3/providers/azure-ad-b2c.md
@@ -15,7 +15,7 @@ https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tena
 
 The **Azure Active Directory Provider** comes with a set of default options:
 
-- [Azure Active Directory Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/azure-ad-b2c.js)
+- [Azure Active Directory Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/azure-ad-b2c.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/basecamp.md
+++ b/versioned_docs/version-v3/providers/basecamp.md
@@ -15,7 +15,7 @@ https://launchpad.37signals.com/integrations
 
 The **Basecamp Provider** comes with a set of default options:
 
-- [Basecamp Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/basecamp.js)
+- [Basecamp Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/basecamp.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/cognito.md
+++ b/versioned_docs/version-v3/providers/cognito.md
@@ -17,7 +17,7 @@ You need to select your AWS region to go the the Cognito dashboard.
 
 The **Amazon Cognito Provider** comes with a set of default options:
 
-- [Amazon Cognito Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/cognito.js)
+- [Amazon Cognito Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/cognito.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/credentials.mdx
+++ b/versioned_docs/version-v3/providers/credentials.mdx
@@ -19,7 +19,7 @@ The functionality provided for credentials based authentication is intentionally
 
 The **Credentials Provider** comes with a set of default options:
 
-- [Credentials Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/credentials.js)
+- [Credentials Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/credentials.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/email.md
+++ b/versioned_docs/version-v3/providers/email.md
@@ -25,7 +25,7 @@ The Email Provider can be used with both JSON Web Tokens and database sessions, 
 
 The **Email Provider** comes with a set of default options:
 
-- [Email Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/email.js)
+- [Email Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/email.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/eveonline.md
+++ b/versioned_docs/version-v3/providers/eveonline.md
@@ -15,7 +15,7 @@ https://developers.eveonline.com/
 
 The **EVE Online Provider** comes with a set of default options:
 
-- [EVE Online Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/eveonline.js)
+- [EVE Online Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/eveonline.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/facebook.md
+++ b/versioned_docs/version-v3/providers/facebook.md
@@ -15,7 +15,7 @@ https://developers.facebook.com/apps/
 
 The **Facebook Provider** comes with a set of default options:
 
-- [Facebook Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/facebook.js)
+- [Facebook Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/facebook.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/google.md
+++ b/versioned_docs/version-v3/providers/google.md
@@ -15,7 +15,7 @@ https://console.developers.google.com/apis/credentials
 
 The **Google Provider** comes with a set of default options:
 
-- [Google Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/google.js)
+- [Google Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/google.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/line.md
+++ b/versioned_docs/version-v3/providers/line.md
@@ -15,7 +15,7 @@ https://developers.line.biz/console/
 
 The **Line Provider** comes with a set of default options:
 
-- [Line Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/line.js)
+- [Line Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/line.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/linkedin.md
+++ b/versioned_docs/version-v3/providers/linkedin.md
@@ -19,7 +19,7 @@ From the Auth tab get the client ID and client secret. On the same tab, add redi
 
 The **LinkedIn Provider** comes with a set of default options:
 
-- [LinkedIn Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/linked-in.js)
+- [LinkedIn Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/linkedin.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/okta.md
+++ b/versioned_docs/version-v3/providers/okta.md
@@ -11,7 +11,7 @@ https://developer.okta.com/docs/reference/api/oidc
 
 The **Okta Provider** comes with a set of default options:
 
-- [Okta Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/okta.js)
+- [Okta Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/okta.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/slack.md
+++ b/versioned_docs/version-v3/providers/slack.md
@@ -16,7 +16,7 @@ https://api.slack.com/apps
 
 The **Slack Provider** comes with a set of default options:
 
-- [Slack Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/slack.js)
+- [Slack Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/slack.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/spotify.md
+++ b/versioned_docs/version-v3/providers/spotify.md
@@ -15,7 +15,7 @@ https://developer.spotify.com/dashboard/applications
 
 The **Spotify Provider** comes with a set of default options:
 
-- [Spotify Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/spotify.js)
+- [Spotify Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/spotify.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/twitch.md
+++ b/versioned_docs/version-v3/providers/twitch.md
@@ -17,7 +17,7 @@ Add the following redirect URL into the console `http://<your-next-app-url>/api/
 
 The **Twitch Provider** comes with a set of default options:
 
-- [Twitch Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitch.js)
+- [Twitch Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/twitch.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/twitter.md
+++ b/versioned_docs/version-v3/providers/twitter.md
@@ -15,7 +15,7 @@ https://developer.twitter.com/en/apps
 
 The **Twitter Provider** comes with a set of default options:
 
-- [Twitter Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/twitter.js)
+- [Twitter Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/twitter.js)
 
 You can override any of the options to suit your own use case.
 

--- a/versioned_docs/version-v3/providers/zoom.md
+++ b/versioned_docs/version-v3/providers/zoom.md
@@ -15,7 +15,7 @@ https://marketplace.zoom.us
 
 The **Zoom Provider** comes with a set of default options:
 
-- [Zoom Provider options](https://github.com/nextauthjs/next-auth/blob/main/src/providers/zoom.js)
+- [Zoom Provider options](https://github.com/nextauthjs/next-auth/blob/ead715219a5d7a6e882a6ba27fa56b03954d062d/src/providers/zoom.js)
 
 You can override any of the options to suit your own use case.
 


### PR DESCRIPTION
## Changes 💡
v4 release landing on main caused a bunch of links to break since most providers were migrated to `.ts`. In versioned docs this is broken because these files are no longer on `main`. Pointed these links in v3 docs to the commit hash of the last v3 release.

Note: "Unreleased documentation" link towards `https://docs-git-next-nextauthjs.vercel.app/` is also broken but unsure where it needs to point.

## Affected issues 🎟


## Screenshot (If Applicable) 📷


