### PR TITLE
Fusionauth configuration

### DIFF
--- a/docs/providers/fusionauth.md
+++ b/docs/providers/fusionauth.md
@@ -24,6 +24,9 @@ providers: [
   FusionAuthProvider({
     id: "fusionauth",
     name: "FusionAuth",
+    idToken: true,
+    jwks_endpoint: process.env.FUSIONAUTH_JWKS_ENDPOINT,
+    wellKnown: process.env.FUSIONAUTH_WELLKNOWN,
     issuer:  process.env.FUSIONAUTH_ISSUER,
     clientId: process.env.FUSIONAUTH_CLIENT_ID,
     clientSecret: process.env.FUSIONAUTH_SECRET,

--- a/docs/providers/fusionauth.md
+++ b/docs/providers/fusionauth.md
@@ -53,6 +53,6 @@ For more information, follow the [FusionAuth 5-minute setup guide](https://fusio
 In the OAuth settings for your application, configure the following.
 
 - Redirect URL
-  - https://localhost:3000/api/auth/callback/fusionauth
+  - http://localhost:3000/api/auth/callback/fusionauth
 - Enabled grants
   - Make sure _Authorization Code_ is enabled.

--- a/docs/providers/fusionauth.md
+++ b/docs/providers/fusionauth.md
@@ -50,6 +50,17 @@ An application can be created at https://your-fusionauth-server-url/admin/applic
 For more information, follow the [FusionAuth 5-minute setup guide](https://fusionauth.io/docs/v1/tech/5-minute-setup-guide).
 :::
 
+Next-Auth uses `RS256` algorithm to decrypt the Id Token, but FusionAuth uses `HS256` algorithm by default. You have to make sure your FusionAuth application's Id Token signing key is RS256 key pair for Next-Auth to work.
+
+In **Settings/Key Master**, create new `RS256` signing key if you don't have one:
+
+- Choose Generate RSA
+- Name the key, .e.g. _RS256_
+- Set the Algorithm to _RSA using SHA-256_
+- Submit
+
+After having your RS256 key pair, go to your application JWT settings, set the `Id Token signing key` to your RS256 key pair.
+
 In the OAuth settings for your application, configure the following.
 
 - Redirect URL


### PR DESCRIPTION
## Changes 💡
Add FusionAuth id token key configuration.
Add `idToken`, `jwks_endpoint`, and `wellKnown` fields to the example to make it work.

## Affected issues 🎟
The issue [#3357](https://github.com/nextauthjs/next-auth/issues/3357) is opened at _nextauthjs/next-auth_ repository.

## Screenshot (If Applicable) 📷


