### PR TITLE
remove database property from options document

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -48,17 +48,6 @@ See the [providers documentation](/configuration/providers/oauth) for a list of 
 
 ---
 
-### database
-
-- **Default value**: `null`
-- **Required**: _No (unless using email provider)_
-
-#### Description
-
-[A database connection string or configuration object.](/configuration/databases)
-
----
-
 ### secret
 
 - **Default value**: `string` (_SHA hash of the "options" object_) in development, no default in production.


### PR DESCRIPTION
This removes the database property from the options document.  Database is no longer available in v4. see discussion [here](https://github.com/nextauthjs/docs/issues/174#issuecomment-993963189)

## Changes 💡
Remove database option from v4 docs

## Affected issues 🎟


## Screenshot (If Applicable) 📷


