### PR TITLE
Add note about the String type for MySQL in Prisma

### DIFF
--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -59,12 +59,12 @@ model Account {
   type               String
   provider           String
   providerAccountId  String
-  refresh_token      String?
-  access_token       String?
+  refresh_token      String?  @db.Text
+  access_token       String?  @db.Text
   expires_at         Int?
   token_type         String?
   scope              String?
-  id_token           String?
+  id_token           String?  @db.Text
   session_state      String?
   oauth_token_secret String?
   oauth_token        String?
@@ -102,7 +102,7 @@ model VerificationToken {
 ```
 
 :::note
-When using the MySQL connector for Prisma, the [Prisma `String` type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string) gets mapped to `varchar(191)` which isn't long enough to store the `id_token` in the `Account` model. To avoid hitting this problem, set the [underlying database type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#mysql) to `Text` as follows: `  id_token           String? @db.Text`.
+When using the MySQL connector for Prisma, the [Prisma `String` type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string) gets mapped to `varchar(191)` which may not be long enough to store fields such as `id_token` in the `Account` model. This can be avoided by explicitly using the `Text` type with `@db.Text`.
 :::
 
 ### Create the database schema with Prisma Migrate

--- a/docs/adapters/prisma.md
+++ b/docs/adapters/prisma.md
@@ -101,6 +101,10 @@ model VerificationToken {
 }
 ```
 
+:::note
+When using the MySQL connector for Prisma, the [Prisma `String` type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string) gets mapped to `varchar(191)` which isn't long enough to store the `id_token` in the `Account` model. To avoid hitting this problem, set the [underlying database type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#mysql) to `Text` as follows: `  id_token           String? @db.Text`.
+:::
+
 ### Create the database schema with Prisma Migrate
 
 ```


### PR DESCRIPTION
## Changes 💡

Add note about the underlying database type for String in Prisma.

Related tweet: https://twitter.com/aidevv_in/status/1471147949136637952
