### PR TITLE
docs(upgrade-to-v4): Fix typo

### DIFF
--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -421,7 +421,7 @@ You can generate a secret to be placed in the `secret` configuration option via 
 $ openssl rand -base64 32
 ```
 
-Therefore, you're NextAuth.js config should look something like this:
+Therefore, your NextAuth.js config should look something like this:
 
 ```javascript title="/pages/api/auth/[...nextauth].js"
 ...


### PR DESCRIPTION
This PR fixes a typo on the "Missing `secret`" section of the upgrade guide docs.

## Changes 💡
- Fixed `you're` for `your`

## Affected issues 🎟
N/A

## Screenshot (If Applicable) 📷
N/A