### PR TITLE
Adding missing TimeToLiveSpecification

### DIFF
--- a/docs/adapters/dynamodb.md
+++ b/docs/adapters/dynamodb.md
@@ -124,4 +124,7 @@ NextAuthTable:
             KeyType: HASH
           - AttributeName: GSI1SK
             KeyType: RANGE
+    TimeToLiveSpecification:
+        AttributeName: expires
+        Enabled: true
 ```

--- a/docs/adapters/dynamodb.md
+++ b/docs/adapters/dynamodb.md
@@ -125,6 +125,6 @@ NextAuthTable:
           - AttributeName: GSI1SK
             KeyType: RANGE
     TimeToLiveSpecification:
-        AttributeName: expires
-        Enabled: true
+      AttributeName: expires
+      Enabled: true
 ```


### PR DESCRIPTION
Updating the CloudFormation template in the NextAuth DynamoDB Adapter example with the missing `TimeToLiveSpecification` config.

The current [NextAuth DynamoDB Adapter](https://next-auth.js.org/adapters/dynamodb) docs are awesome and include CDK and CloudFormation examples that help provision the database. While the CDK example appears correct and complete, the CloudFormation example is missing the `TimeToLiveSpecification` configuration. This change updates the example to include this missing configuration.

## Changes 💡

- Documentation update that reflects adding the missing `TimeToLiveSpecification` with the `expires` attribute to the NextAuth DynamoDB Adapter page.

## Affected issues 🎟

N/A. The corresponding AWS CDK example looks correct.

## Screenshot (If Applicable) 📷

The CDK example, which correctly includes the `expires` attribute for configuring the `TimeToLiveSpecification`.

<img width="1324" alt="Screen Shot 2021-12-28 at 4 45 52 AM" src="https://user-images.githubusercontent.com/1203617/147553274-d65a92ee-d766-4609-99d3-ba350c65a96b.png">

The CloudFormation example, which is **missing** the `TimeToLiveSpecification` configuration block.

<img width="1324" alt="Screen Shot 2021-12-28 at 4 46 10 AM" src="https://user-images.githubusercontent.com/1203617/147553293-7576c5ad-e7e0-45ff-ab30-ef70094820d2.png">
