### PR TITLE
fix(docs): update NextAuthOptions.session option

### DIFF
--- a/docs/adapters/models.md
+++ b/docs/adapters/models.md
@@ -51,7 +51,7 @@ Linking and unlinking accounts through an API is a planned feature: https://gith
 
 ## Session
 
-The Session model is used for database sessions. It is not used if JSON Web Tokens are enabled. Keep in mind, that you can use a database to persist Users and Accounts, and still use JWT for sessions. See the [`session.jwt`](/configuration/options#session) option.
+The Session model is used for database sessions. It is not used if JSON Web Tokens are enabled. Keep in mind, that you can use a database to persist Users and Accounts, and still use JWT for sessions. See the [`session.strategy`](/configuration/options#session) option.
 
 A single User can have multiple Sessions, each Session can only have one User.
 


### PR DESCRIPTION
## Changes 💡

Change `jwt: true` to `strategy: "jwt"`.

The documentation on the db models page is referencing the previous session option (`jwt: true`) but [the current option](https://next-auth.js.org/configuration/options#session) is `strategy: "jwt"`. 👍

- See also in the [example repo](https://github.com/nextauthjs/next-auth-typescript-example/blob/df66e3f1796f054064ec8b2807f09c9889dda7e4/pages/api/auth/%5B...nextauth%5D.ts#L71)

## Affected issues 🎟


## Screenshot (If Applicable) 📷

<img width="842" alt="Screen Shot 2021-12-28 at 08 43 11" src="https://user-images.githubusercontent.com/44626877/147536489-6f0fc638-00d5-4af6-bd14-1cc4b68b2b7b.png">

