### PR TITLE
Typo on Code Example for credentials.md

### DIFF
--- a/docs/configuration/providers/credentials.md
+++ b/docs/configuration/providers/credentials.md
@@ -10,7 +10,7 @@ The Credentials provider allows you to handle signing in with arbitrary credenti
 It is intended to support use cases where you have an existing system you need to authenticate users against.
 
 ```js title="pages/api/auth/[...nextauth].js"
-import CredentialsProvider from `next-auth/providers/credentials`
+import CredentialsProvider from "next-auth/providers/credentials"
 ...
 providers: [
   CredentialsProvider({


### PR DESCRIPTION
## Changes 💡
Changed line 13 where import of CredentialsProvider was sourced using ` next-auth/providers/credentials` rather than " next-auth/providers/credentials";

## Affected issues 🎟
Caused error in code when the code snippet is copied and placed in code due to syntax error.

