### PR TITLE
Update default image size for Azure-AD provider

### DIFF
--- a/docs/providers/azure-ad.md
+++ b/docs/providers/azure-ad.md
@@ -38,7 +38,7 @@ AZURE_AD_TENANT_ID=<copy the tenant id here>
 That will default the tenant to use the `common` authorization endpoint. [For more details see here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints).
 
 :::note
-Azure AD returns the profile picture in an ArrayBuffer, instead of just a URL to the image, so our provider converts it to a base64 encoded image string and returns that instead. See: https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples. The default image size is 64x64 to avoid [running out of space](https://next-auth.js.org/faq#:~:text=What%20are%20the%20disadvantages%20of%20JSON%20Web%20Tokens%3F) in case the session is saved as a JWT.
+Azure AD returns the profile picture in an ArrayBuffer, instead of just a URL to the image, so our provider converts it to a base64 encoded image string and returns that instead. See: https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#examples. The default image size is 48x48 to avoid [running out of space](https://next-auth.js.org/faq#:~:text=What%20are%20the%20disadvantages%20of%20JSON%20Web%20Tokens%3F) in case the session is saved as a JWT.
 :::
 
 In `pages/api/auth/[...nextauth].js` find or add the `AzureAD` entries:


### PR DESCRIPTION
## Changes 💡
According to the provider source, the default image size returned by Azure-AD is 48x48 and not 64x64.
https://github.com/nextauthjs/next-auth/blob/main/src/providers/azure-ad.ts

## Affected issues 🎟
None

## Screenshot (If Applicable) 📷
N/a

