### PR TITLE
Added documentation on how to use a custom base path in NextAuth

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -13,7 +13,7 @@ When deploying to production, set the `NEXTAUTH_URL` environment variable to the
 NEXTAUTH_URL=https://example.com
 ```
 
-If your Next.js application uses a custom base path, specify the route to the API endpoint in full.
+If your Next.js application uses a custom base path, specify the route to the API endpoint in full. More informations about the usage of custom base path [here](#custom-base-path).
 
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
 
@@ -470,3 +470,32 @@ cookies: {
 :::warning
 Using a custom cookie policy may introduce security flaws into your application and is intended as an option for advanced users who understand the implications. Using this option is not recommended.
 :::
+
+---
+
+### Custom base path
+When your Next.js application uses a custom base path, set the `NEXTAUTH_URL` environment variable to the route to the API endpoint in full - as in the example below.
+
+Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.
+  
+#### Example
+In this example, the custom base path used is `/custom-route`.
+
+```
+NEXTAUTH_URL=https://example.com/custom-route/api/auth
+```
+
+```jsx title="pages/_app.js"
+import { SessionProvider } from "next-auth/react"
+
+export default function App({
+  Component,
+  pageProps: { session, ...pageProps },
+}) {
+  return (
+    <SessionProvider session={session} basePath="/custom-route/api/auth">
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
+}
+```

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -17,6 +17,10 @@ If your Next.js application uses a custom base path, specify the route to the AP
 
 _e.g. `NEXTAUTH_URL=https://example.com/custom-route/api/auth`_
 
+:::tip
+When you're using a custom base path, you will need to pass the `basePath` page prop to the `<SessionProvider>`. More informations [here](/getting-started/client#custom-base-path).
+:::
+
 :::note
 On [Vercel](https://vercel.com) deployments, we will read the `VERCEL_URL` environment variable, so you won't need to define `NEXTAUTH_URL`.
 :::
@@ -472,30 +476,3 @@ Using a custom cookie policy may introduce security flaws into your application 
 :::
 
 ---
-
-### Custom base path
-When your Next.js application uses a custom base path, set the `NEXTAUTH_URL` environment variable to the route to the API endpoint in full - as in the example below.
-
-Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.
-  
-#### Example
-In this example, the custom base path used is `/custom-route`.
-
-```
-NEXTAUTH_URL=https://example.com/custom-route/api/auth
-```
-
-```jsx title="pages/_app.js"
-import { SessionProvider } from "next-auth/react"
-
-export default function App({
-  Component,
-  pageProps: { session, ...pageProps },
-}) {
-  return (
-    <SessionProvider session={session} basePath="/custom-route/api/auth">
-      <Component {...pageProps} />
-    </SessionProvider>
-  )
-}
-```

--- a/docs/getting-started/client.md
+++ b/docs/getting-started/client.md
@@ -501,3 +501,30 @@ The value for `refetchInterval` should always be lower than the value of the ses
 :::note
 See [**the Next.js documentation**](https://nextjs.org/docs/advanced-features/custom-app) for more information on **\_app.js** in Next.js applications.
 :::
+
+### Custom base path
+When your Next.js application uses a custom base path, set the `NEXTAUTH_URL` environment variable to the route to the API endpoint in full - as in the example below and as explained [here](/configuration/options#nextauth_url).
+
+Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.
+  
+#### Example
+In this example, the custom base path used is `/custom-route`.
+
+```
+NEXTAUTH_URL=https://example.com/custom-route/api/auth
+```
+
+```jsx title="pages/_app.js"
+import { SessionProvider } from "next-auth/react"
+
+export default function App({
+  Component,
+  pageProps: { session, ...pageProps },
+}) {
+  return (
+    <SessionProvider session={session} basePath="/custom-route/api/auth">
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
+}
+```

--- a/docs/getting-started/client.md
+++ b/docs/getting-started/client.md
@@ -505,7 +505,7 @@ See [**the Next.js documentation**](https://nextjs.org/docs/advanced-features/cu
 ### Custom base path
 When your Next.js application uses a custom base path, set the `NEXTAUTH_URL` environment variable to the route to the API endpoint in full - as in the example below and as explained [here](/configuration/options#nextauth_url).
 
-Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.
+Also, make sure to pass the `basePath` page prop to the `<SessionProvider>` – as in the example below – so your custom base path is fully configured and used by NextAuth.js.
   
 #### Example
 In this example, the custom base path used is `/custom-route`.


### PR DESCRIPTION
After being blocked myself for several days, I came across a discussion (#3635) referring to the basePath property of the SessionProvider. I think it's important to add these explanations because I couldn't find anything about it on the current documentation.

## Changes 💡
Added a section dedicated to the use of a custom base path in the documentation related to the configuration.

## Affected issues 🎟
Missing informations about usage of custom base path.


