### PR TITLE
Fixed description of change to expires_at

### DIFF
--- a/docs/getting-started/upgrade-to-v4.md
+++ b/docs/getting-started/upgrade-to-v4.md
@@ -333,8 +333,8 @@ The way we save data with adapters have slightly changed. With the new Adapter A
 - `provider_id`/`providerId` renamed to `provider` on Account
 - `provider_type`/`providerType` renamed to `type` on Account
 - `provider_account_id`/`providerAccountId` on Account is consistently named `providerAccountId`
-- `access_token_expires`/`accessTokenExpires` on Account renamed to `expires_in`
-- New fields on Account: `expires_at`, `token_type`, `scope`, `id_token`, `session_state`
+- `access_token_expires`/`accessTokenExpires` on Account renamed to `expires_at`
+- New fields on Account: `token_type`, `scope`, `id_token`, `session_state`
 - `verification_requests` table has been renamed to `verification_tokens`
 
 <!-- REVIEW: Would something like this below be helpful? -->


### PR DESCRIPTION
The change description now matches the [Models](https://next-auth.js.org/adapters/models).