### PR TITLE
fix(docs): add Salesforce troubleshooting info

### DIFF
--- a/docs/providers/salesforce.md
+++ b/docs/providers/salesforce.md
@@ -28,3 +28,29 @@ providers: [
 ]
 ...
 ```
+
+## Troubleshooting
+
+If you run into an error saying something like `id_token detected in the response...`, you may have to add the scope parameter to your Salesforce config like so:
+
+```js
+import NextAuth from "next-auth/next";
+import SalesFoceProvider from "next-auth/providers/salesforce";
+
+export default NextAuth({
+  ...,
+  providers: [
+    SalesFoceProvider({
+      clientId: "SALESFORCE_CLIENT_ID",
+      clientSecret: "SALESFORCE_CLIENT_SECRET",
+      authorization: {
+        params: {
+          scope: "api id web",
+        },
+      },
+    }),
+  ],
+});
+```
+      
+See: https://github.com/nextauthjs/next-auth/issues/2524#issuecomment-1022544845


### PR DESCRIPTION
## Changes 💡

I don't have a Salesforce account to 100% verify this, therefore I've simply added it as troubleshooting info, instead of adding this scope info into the default way of doing things for this provider.

See the following issue comment for more info: https://github.com/nextauthjs/next-auth/issues/2524#issuecomment-1022544845

## Affected issues 🎟


## Screenshot (If Applicable) 📷


