### PR TITLE
Restructure Sign In with Apple dev server instructions

### DIFF
--- a/docs/providers/apple.md
+++ b/docs/providers/apple.md
@@ -44,12 +44,11 @@ The TeamID is located on the top right after logging in.
 :::
 
 :::tip
-The KeyID is located after you create the Key look for before you download the k8 file.
+The KeyID is located after you create the key. Look for it before you download the k8 file.
 :::
 
-## Instructions
 
-### Testing
+## Testing on a development server
 
 :::tip
 Apple requires all sites to run HTTPS (including local development instances).
@@ -59,32 +58,27 @@ Apple requires all sites to run HTTPS (including local development instances).
 Apple doesn't allow you to use localhost in domains or subdomains.
 :::
 
-The following guides may be helpful:
+### Host name resolution
 
-- [How to setup localhost with HTTPS with a Next.js app](https://medium.com/@anMagpie/secure-your-local-development-server-with-https-next-js-81ac6b8b3d68)
+Edit your host file and point your site to `127.0.0.1`.
 
-- [Guide to configuring Sign in with Apple](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple)
+_Linux/macOS_
+```
+sudo echo '127.0.0.1 dev.example.com' >> /etc/hosts
+```
 
-### Example server
-
-You will need to edit your host file and point your site at `127.0.0.1`
-
-[How to edit my host file?](https://phoenixnap.com/kb/how-to-edit-hosts-file-in-windows-mac-or-linux)
-
-On Windows (Run Powershell as administrator)
-
+_Windows_ (run PowerShell as administrator)
 ```ps
-Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1`tdev.example.com" -Force
+Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 dev.example.com" -Force
 ```
 
-```
-127.0.0.1 dev.example.com
-```
+More info: [How to edit my host file?](https://phoenixnap.com/kb/how-to-edit-hosts-file-in-windows-mac-or-linux)
 
-#### Create certificate
+### Create certificate
 
-Creating a certificate for localhost is easy with openssl . Just put the following command in the terminal. The output will be two files: localhost.key and localhost.crt.
+Create a directory `certificates` and add the certificate files `localhost.key` and `localhost.crt`, which you generate using OpenSSL:
 
+_Linux/macOS_
 ```bash
 openssl req -x509 -out localhost.crt -keyout localhost.key \
   -newkey rsa:2048 -nodes -sha256 \
@@ -92,23 +86,19 @@ openssl req -x509 -out localhost.crt -keyout localhost.key \
    printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 ```
 
-:::tip
-**Windows**
+_Windows_
 
-The OpenSSL executable is distributed with [Git](https://git-scm.com/download/win]9) for Windows.
-Once installed you will find the openssl.exe file in `C:/Program Files/Git/mingw64/bin` which you can add to the system PATH environment variable if it’s not already done.
+The OpenSSL executable is distributed with [Git](https://git-scm.com/download/win) for Windows. Once installed you will find the openssl.exe file in `C:\Program Files\Git\mingw64\bin`, which you can add to the system PATH environment variable if it’s not already done.
 
-Add environment variable `OPENSSL_CONF=C:/Program Files/Git/mingw64/ssl/openssl.cnf`
+Add environment variable `OPENSSL_CONF=C:\Program Files\Git\mingw64\ssl\openssl.cnf`
 
-```bash
+```cmd
  req -x509 -out localhost.crt -keyout localhost.key \
   -newkey rsa:2048 -nodes -sha256 \
   -subj "/CN=localhost"
 ```
 
-:::
-
-Create directory `certificates` and place `localhost.key` and `localhost.crt`
+### Deploy to server
 
 You can create a `server.js` in the root of your project and run it with `node server.js` to test Sign in with Apple integration locally:
 
@@ -137,3 +127,9 @@ app.prepare().then(() => {
   })
 })
 ```
+
+### Helpful guides
+
+- [How to setup localhost with HTTPS with a Next.js app](https://medium.com/@anMagpie/secure-your-local-development-server-with-https-next-js-81ac6b8b3d68)
+
+- [Guide to configuring Sign in with Apple](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple)


### PR DESCRIPTION
It was confusing to follow. This cleans it up a bunch.