### PR TITLE
feat: add showcase page

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,13 @@
+---
+id: showcase
+title: Showcase
+---
+
+NextAuth.js is used all over the web. Here's a selection of popular users.
+
+- Lowdefy (https://lowdefy.com/)
+- Vercel Platforms Starter Kit (https://github.com/vercel/platforms)
+- Cal.com (https://cal.com)
+- tldraw.com (https://www.tldraw.com/)
+- leerob.io (https://leerob.io/)
+- island.is (https://github.com/island-is/island.is)

--- a/sidebars.js
+++ b/sidebars.js
@@ -72,5 +72,6 @@ module.exports = {
     },
     "warnings",
     "errors",
+    "showcase",
   ],
 }


### PR DESCRIPTION
## Changes 💡

Added `/showcase` page with links of NextAuth.js users.

If anyone knows any other cool ones please let me know / add them!

I'd also love to get like 3-5 logos of big companies using next-auth on our docs homepage if possible :crossed_fingers: 


## Affected issues 🎟


## Screenshot (If Applicable) 📷


