### PR TITLE
docs(refresh-token): update jwt handler to read from correct field

### DIFF
--- a/docs/tutorials/refresh-token-rotation.md
+++ b/docs/tutorials/refresh-token-rotation.md
@@ -88,7 +88,7 @@ export default NextAuth({
       if (account && user) {
         return {
           accessToken: account.access_token,
-          accessTokenExpires: Date.now() + account.expires_in * 1000,
+          accessTokenExpires: account.expires_at * 1000,
           refreshToken: account.refresh_token,
           user,
         }


### PR DESCRIPTION
## Changes 💡

The new field, `expires_at` is actually in seconds and represents a time in the future, not the amount of time before a token expires. 

The docs, as written before this change, were extending the lifespan of the original token well beyond what was valid causing the refresh to never be triggered.
This change fixes that by removing the addition of `Date.now()` and simply converting the time we get into milliseconds.

## Affected issues 🎟

N/A

## Screenshot (If Applicable) 📷

N/A