### PR TITLE
Fixes refresh token example

### DIFF
--- a/docs/tutorials/refresh-token-rotation.md
+++ b/docs/tutorials/refresh-token-rotation.md
@@ -88,7 +88,7 @@ export default NextAuth({
       if (account && user) {
         return {
           accessToken: account.access_token,
-          accessTokenExpires: Date.now() + account.expires_in * 1000,
+          accessTokenExpires: account.expires_at * 1000,
           refreshToken: account.refresh_token,
           user,
         }


### PR DESCRIPTION
## Changes 💡
Fixes refresh token example, on initial signin `account.expires_in` is undefined it should reference `account.expires_at`

## Affected issues 🎟
## Screenshot (If Applicable) 📷

